### PR TITLE
Added prettier timestamp display to cmsa_15min view

### DIFF
--- a/api/src/peoplemeasurement/migrations/0004_cmsa_15min_view_20190926_1130.py
+++ b/api/src/peoplemeasurement/migrations/0004_cmsa_15min_view_20190926_1130.py
@@ -32,7 +32,7 @@ SELECT
 FROM
     (SELECT
         *,
-        EXTRACT(epoch from "timestamp")::int / 60 / 15 as timestamp_rounded,
+        to_timestamp(EXTRACT(epoch from timestamp)::int / 60 / 15 * 15 * 60) as timestamp_rounded,  -- round down for every 15 minutes
         COUNT(*) OVER (PARTITION BY EXTRACT(epoch from "timestamp")::int / 60 / 15, sensor) AS based_on_x_messages
     FROM peoplemeasurement_peoplemeasurement
     ) s,


### PR DESCRIPTION
The timestamp which was shown in the aggregation made no sense and only worked as a grouping mechanism. This has been converted back to a timestamp so that analysist can better work with it.