### PR TITLE
By default run three days of aggregations

### DIFF
--- a/api/src/passage/management/commands/passage_igor_hour_aggregation.py
+++ b/api/src/passage/management/commands/passage_igor_hour_aggregation.py
@@ -147,5 +147,7 @@ class Command(BaseCommand):
                 run_date = run_date + timedelta(days=1)
 
         else:
-            run_date = date.today() - timedelta(days=1)
-            self._run_query_from_date(run_date)
+            for i in range(3, 0, -1):
+                # by default update the aggregations for the last three days
+                run_date = date.today() - timedelta(days=i)
+                self._run_query_from_date(run_date)

--- a/api/src/passage/management/commands/passage_zwaar_verkeer_hour_aggregation.py
+++ b/api/src/passage/management/commands/passage_zwaar_verkeer_hour_aggregation.py
@@ -166,5 +166,7 @@ class Command(BaseCommand):
                 run_date = run_date + timedelta(days=1)
 
         else:
-            run_date = date.today() - timedelta(days=1)
-            self._run_query_from_date(run_date)
+            for i in range(3, 0, -1):
+                # by default update the aggregations for the last three days
+                run_date = date.today() - timedelta(days=i)
+                self._run_query_from_date(run_date)


### PR DESCRIPTION
Passage data can be sent up to three days after the event.
Under normal conditions data will be sent near realtime, but
when problems occurr it can be send later. To ensure the
aggregations are always complete we'll update them for
the last three days.